### PR TITLE
Plugin refactoring and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Add the following to your `project/plugins.sbt`:
 
 ## sbt-0.13.7+
 
-    resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
-
-    addSbtPlugin("com.github.sbtliquibase" % "sbt-liquibase" % "0.1.0-SNAPSHOT")
+    addSbtPlugin("com.github.sbtliquibase" % "sbt-liquibase" % "0.2.0")
 
 ### Step 2: Activate sbt-liquibase-plugin in your build
 
@@ -31,10 +29,6 @@ Add the following to your 'build.sbt' ( if you are using build.sbt )
     liquibaseDriver   := "com.mysql.jdbc.Driver"
 
     liquibaseUrl      := "jdbc:mysql://localhost:3306/test_db?createDatabaseIfNotExist=true"
-
-Or if you are using a build object extending from Build:
-
-    TODO
 
 ## Settings
 
@@ -183,7 +177,7 @@ Or if you are using a build object extending from Build:
                 <td>Rolls back the last {int i} change sets applied to the database</td>
         </tr>
         <tr>
-                <td><b>liquibase-rollback-sql-count</b> {int}</td>
+                <td><b>liquibase-rollback-count-sql</b> {int}</td>
                 <td>Writes SQL to roll back the last {int i} change sets to STDOUT applied to the database</td>
         </tr>
 
@@ -199,10 +193,10 @@ Or if you are using a build object extending from Build:
                 <td><b>liquibase-future-rollback-sql</b></td>
                 <td>Writes SQL to roll back the database to the current state after the changes in the changelog have been applied.</td>
         </tr>
-	<tr>
-		<td><b>liquibase-drop-all</b></td>
-		<td>Drop all tables</td>
-	</tr>
+        <tr>
+                <td><b>liquibase-drop-all</b></td>
+                <td>Drop all tables</td>
+        </tr>
 
 </table>
 
@@ -218,8 +212,8 @@ Please file bugs or feature requests and I will do my best to address them.
 Acknoledgements
 ---------------
 Inspiration from previous work done by others on the following projects was an enourmous help.
- * sbt-liquibase plugin for sbt 0.11/0.12 (thanks for actually making this plugin in the furst place!)
- * sbt-web (helped to bring this up to speed with 0.13 plugin standars)
+ * sbt-liquibase plugin for sbt 0.11/0.12 (thanks for actually making this plugin in the first place!)
+ * sbt-web (helped to bring this up to speed with 0.13 plugin standarts)
  * sbt-assembly (learned a lot about scripted sbt tests)
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.github.sbtliquibase"
 
 name := "sbt-liquibase"
 
-version := "0.1.0-SNAPSHOT"
+version := "0.2.0"
 
 licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 
@@ -13,7 +13,7 @@ homepage := Some(url("https://github.com/sbtliquibase/sbt-liquibase-plugin"))
 
 crossScalaVersions := Seq("2.10.4")
 
-libraryDependencies += "org.liquibase" % "liquibase-core" % "3.3.1"
+libraryDependencies += "org.liquibase" % "liquibase-core" % "3.5.3"
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.12

--- a/src/sbt-test/basic/update/build.sbt
+++ b/src/sbt-test/basic/update/build.sbt
@@ -2,6 +2,7 @@ import java.sql.{Connection, DriverManager}
 
 import com.github.sbtliquibase.SbtLiquibase
 
+lazy val multipleTasks = taskKey[Unit]("Check multiple tasks running")
 
 lazy val test = (project in file("."))
   .enablePlugins(SbtLiquibase)
@@ -18,7 +19,14 @@ lazy val test = (project in file("."))
 
     libraryDependencies ++= Seq(
       "com.h2database" % "h2" % "1.4.182"
-    )
+    ),
+
+    multipleTasks := {},
+
+    multipleTasks <<= multipleTasks.dependsOn(Def.sequential(
+      liquibaseDropAll,
+      liquibaseUpdate
+    ))
   )
 
 val checkTablesTasks = TaskKey[Unit]("checkTables")

--- a/src/sbt-test/basic/update/project/plugins.sbt
+++ b/src/sbt-test/basic/update/project/plugins.sbt
@@ -18,5 +18,5 @@
 
 libraryDependencies ++= Seq(
   "com.h2database" % "h2" % "1.4.182",
-  "org.liquibase" % "liquibase-core" % "3.3.0"
+  "org.liquibase" % "liquibase-core" % "3.5.3"
 )

--- a/src/sbt-test/basic/update/test
+++ b/src/sbt-test/basic/update/test
@@ -2,3 +2,6 @@
 > liquibaseUpdate
 # check if update ran
 > checkTables
+# check if multiple tasks in the single run works well
+> multipleTasks
+> checkTables


### PR DESCRIPTION
This pull request contains multiple improvements for the project:
- Fixed #7: upgrade liquibase version to the currently latest 3.5.3 version.
- Fixed issue with multiple tasks running. Previously, if you created a task, which contains multiple liquibase tasks, all tasks after first will fail. This happens because all tasks shared the same `liquibaseInstance` object and after first task connection to the db will be closed (see `RichLiquibase.execAndClose`). To fix this, I changed the type of `liquibaseInstance` to `TaskKey[() => Liquibase]`. So, all tasks will create their own instance and DB connection. I added tests for this.
- Changed type of `liquibaseUrl`, `liquibaseUsername`, and `liquibasePassword` from `SettingKey` to `TaskKey` to make them lazy.
- Did some refactoring:
  - Combined `RichLiquibase` implicit conversion with class definition. It's slightly reduced code size.
  - Removed `liquibaseDatabase` task, because its definition is pretty big, but it is internal thing and no one should use it in their own build definition.
- Updated README.md file.
- Fixed #9: move from 0.1.0-SNAPSHOT to 0.2.0. This _snapshot_ stuff is very deterrent, but this plugin is pretty stable and works well. I didn't test public publishing (I used only `publishLocal`).

This plugin is the best sbt liquibase plugin I found (I checked _a lot_), so It would be really cool if it will evolve.
